### PR TITLE
building pardot data marts for ER Analytics

### DIFF
--- a/models/intermediate/int_pardot__activities_join_enriched.sql
+++ b/models/intermediate/int_pardot__activities_join_enriched.sql
@@ -1,0 +1,28 @@
+with visitor_activity as (
+    select *
+    from {{ ref('stg_pardot__visitor_activity') }}
+),
+
+campaigns as (
+    select *
+    from {{ ref('stg_pardot__campaign') }}
+),
+
+list_emails as (
+    select *
+    from {{ ref('stg_pardot__list_email') }}
+)
+
+select 
+    visitor_activity.*,
+    list_email_name,
+    list_email_subject,
+    list_email_sent_at,
+    campaigns.campaign_name as activity_campaign_name 
+
+from visitor_activity
+
+left join campaigns on visitor_activity.campaign_id = campaigns.campaign_id
+
+left join list_emails on visitor_activity.list_email_id = list_emails.list_email_id
+

--- a/models/intermediate/int_pardot__activities_join_enriched.sql
+++ b/models/intermediate/int_pardot__activities_join_enriched.sql
@@ -15,9 +15,19 @@ list_emails as (
 
 select 
     visitor_activity.*,
+    
+    is_mmus_formated_list_email_name,
+    list_email_natural_key,
+    list_email_sent_at,
+    list_email_keyword_segment,
+    list_email_keyword_status,
+    list_email_keyword_type,
+    list_email_name_parsed_topic,
+
     list_email_name,
     list_email_subject,
-    list_email_sent_at,
+
+    
     campaigns.campaign_name as activity_campaign_name 
 
 from visitor_activity

--- a/models/intermediate/int_pardot__prospects_join_enriched.sql
+++ b/models/intermediate/int_pardot__prospects_join_enriched.sql
@@ -1,0 +1,38 @@
+with pardot_prospects as (
+    select *
+    from {{ ref('stg_pardot__prospect') }}
+),
+
+salesforce_contacts as (
+    select * 
+    from {{ ref('stg_salesforce__contacts') }}
+),
+
+pardot_campaigns as (
+    select 
+        campaign_id,
+        campaign_name,
+        campaign_salesforce_id
+    from {{ ref('stg_pardot__campaign') }}
+),
+
+joined as (
+    select
+        pardot_prospects.prospect_id,
+        
+        prospect_campaigns.campaign_name as prospect_campaign_name,
+        prospect_campaigns.campaign_salesforce_id as prospect_campaign_salesforce_id,
+
+        pardot_prospects.crm_contact_fid,
+        salesforce_contacts.account_id
+    
+    from pardot_prospects
+
+    left join salesforce_contacts
+    on pardot_prospects.crm_contact_fid = salesforce_contacts.contact_id
+
+    left join pardot_campaigns as prospect_campaigns
+    using (campaign_id)
+)
+
+select * from joined

--- a/models/pardot__activities.sql
+++ b/models/pardot__activities.sql
@@ -1,8 +1,6 @@
 with activities as (
-    select 
-    * 
-
-from {{ ref('int_pardot__activities_join_enriched') }}
+    select * 
+    from {{ ref('int_pardot__activities_join_enriched') }}
 ),
 
 prospects as (

--- a/models/pardot__activities.sql
+++ b/models/pardot__activities.sql
@@ -1,0 +1,25 @@
+with activities as (
+    select 
+    * 
+
+from {{ ref('int_pardot__activities_join_enriched') }}
+),
+
+prospects as (
+    select *
+    from {{ ref('int_pardot__prospects_join_enriched') }}  
+),
+
+joined as (
+    select
+        *
+
+    from activities
+
+    left join prospects using (prospect_id)
+)
+
+select
+    *
+
+from joined

--- a/models/pardot__prospects.sql
+++ b/models/pardot__prospects.sql
@@ -8,10 +8,20 @@ with prospects as (
     select *
     from {{ ref('int__activities_by_prospect') }}
 
+), enriched_prospects as (
+
+    select 
+        prospect_id,
+        account_id,
+    from {{ ref('int_pardot__prospects_join_enriched') }}
+
 ), joined as (
 
     select
         prospects.*,
+
+        enriched_prospects.account_id,
+
         {% for event_type in var('prospect_metrics_activity_types') %}
         coalesce(activities.count_activity_{{ event_type|lower|replace(' ','_') }},0) as count_activity_{{ event_type|lower|replace(' ','_') }},
         activities.most_recent_{{ event_type|lower|replace(' ','_') }}_activity_timestamp,
@@ -23,6 +33,8 @@ with prospects as (
         activities.most_recent_email_activity_timestamp
     from prospects
     left join activities
+        using (prospect_id)
+    left join enriched_prospects
         using (prospect_id)
 
 )

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,2 @@
 packages:
-  - package: fivetran/pardot_source
-    version: [">=0.6.0", "<0.7.0"]
+  - local: /usr/app/dbt/temp/dbt_pardot_source


### PR DESCRIPTION
## What this PR does
creates marts: 
- `pardot__activities`, which at the grain of pardot `visitor_activity`, provides timestamped records of key pardot events include email send, email open, email click, spam complaint, etc
  - this wide table is primarily enriched by `list_email`, which in these PRs is enhanced to show key IRC attributes as encoded in list email name by the MMUS team
- `pardot_prospects`, which as the grain of inidividual pardot contacts, includes foreign keys for salesforce `contact` and `account`


## How to view changes
`select * from er_dev.dbt_tylerwood_dev.pardot__activities`