### PR TITLE
`pardot` databricks migration - building / fixing models

### DIFF
--- a/models/pardot__prospects.sql
+++ b/models/pardot__prospects.sql
@@ -12,7 +12,7 @@ with prospects as (
 
     select 
         prospect_id,
-        account_id,
+        account_id
     from {{ ref('int_pardot__prospects_join_enriched') }}
 
 ), joined as (


### PR DESCRIPTION
## What this does and why
As part of issue # 1290 on the er-analytics-dbt repo, this issue builds / migrates all models within the fivetran forked `pardot` package on databricks

Models which have been migrated

- [x] `int__opportunity_tmp` (built successfully on Databricks)
- [x] `pardot__activities` (built successfully on Databricks)
- [x] `pardot__campaigns` (built successfully on Databricks)
- [x] `pardot__lists` (built successfully on Databricks)
- [x] `pardot__opportunities` (built successfully on Databricks)
- [x] pardot__prospects (failed on initial build, fixed by removing trailing comma before the FROM clause on a CTE within the model)

note: there are also 5 empheral models which live within the pardot package intermediate folder, which will not be built as models or tested within this PR. These models are listed out below:

- int__activities_by_list
- int__activities_by_prospect
- int__opportunities_by_campaign
- int_pardot__activities_join_enriched
- int_pardot__prospects_join_enriched



## PR type

- [x] Databricks migration

## Related Issues and PRs
[#1290 ](https://github.com/theirc/er-analytics-dbt/issues/1290)

## dbt dev/local run logs

```
(dbt-env-dbx) PS C:\Users\AndrewLo\Repos\er-analytics-dbt> dbt run --select tag:email --exclude pardot_source
13:54:14  Running with dbt=1.9.7
C:\Users\AndrewLo\Repos\er-analytics-dbt\dbt-env-dbx\lib\site-packages\pydantic\_internal\_config.py:373: UserWarning: Valid config keys have changed in V2:
* 'allow_population_by_field_name' has been renamed to 'validate_by_name'
  warnings.warn(message, UserWarning)
  warnings.warn(message, UserWarning)
13:54:15  Registered adapter: databricks=1.9.7
13:54:17  [WARNING]: Configuration paths exist in your dbt_project.yml file which do not apply to any resources.
There are 1 unused configuration paths:
- seeds.er_analytics_dbt.data_processing
13:54:18  Found 236 models, 3 snapshots, 398 data tests, 55 seeds, 223 sources, 2049 macros
13:54:18
13:54:18  Concurrency: 4 threads (target='databricks_local')
13:54:18
13:54:20  1 of 6 START sql view model dbt_andrewlobo_silver_pardot.int__opportunity_tmp .. [RUN]
13:54:20  2 of 6 START sql table model dbt_andrewlobo_silver_pardot.pardot__opportunities  [RUN]
13:54:20  3 of 6 START sql table model dbt_andrewlobo_silver_pardot.pardot__activities ... [RUN]
13:54:20  4 of 6 START sql table model dbt_andrewlobo_silver_pardot.pardot__prospects .... [RUN]
13:54:32  1 of 6 OK created sql view model dbt_andrewlobo_silver_pardot.int__opportunity_tmp  [OK in 12.55s]
13:54:40  5 of 6 START sql table model dbt_andrewlobo_silver_pardot.pardot__campaigns .... [RUN]
13:55:11  2 of 6 OK created sql table model dbt_andrewlobo_silver_pardot.pardot__opportunities  [OK in 51.68s]
13:56:27  5 of 6 OK created sql table model dbt_andrewlobo_silver_pardot.pardot__campaigns  [OK in 107.85s]
14:06:26  4 of 6 OK created sql table model dbt_andrewlobo_silver_pardot.pardot__prospects  [OK in 726.22s]
14:06:26  6 of 6 START sql table model dbt_andrewlobo_silver_pardot.pardot__lists ........ [RUN]
14:07:20  6 of 6 OK created sql table model dbt_andrewlobo_silver_pardot.pardot__lists ... [OK in 53.63s]
14:11:45  3 of 6 OK created sql table model dbt_andrewlobo_silver_pardot.pardot__activities  [OK in 1045.39s]
14:11:48
14:11:48  Finished running 5 table models, 1 view model in 0 hours 17 minutes and 29.35 seconds (1049.35s).
14:11:49
14:11:49  Completed successfully
14:11:49
14:11:49  Done. PASS=6 WARN=0 ERROR=0 SKIP=0 TOTAL=6
```

Screenshot of models on my dev folder on databricks:

<img width="306" height="229" alt="image" src="https://github.com/user-attachments/assets/39153c0b-3ab0-44cd-ac00-d018e02b2804" />
