### PR TITLE
Pardot Email URL builder enhancements - `pardot` pipeline

### DIFF
--- a/models/intermediate/int_pardot__activities_join_enriched.sql
+++ b/models/intermediate/int_pardot__activities_join_enriched.sql
@@ -27,6 +27,15 @@ select
     list_email_name,
     list_email_subject,
 
+    /* An email specific URL builder was rolled out globally in late FY25, with full adoption across markets from FY26. See https://theirc.github.io/URLBuilder/#emailUrlGenPage . 
+    New attributes from the URL builder created on stg_pardot__list_email and passed through below */
+    email_url_builder_month_abbreviated,
+    email_url_builder_month_full_name,
+    email_url_builder_version_number,
+    email_url_builder_audience_segment_code,
+    email_url_builder_test_variant,
+    is_email_url_builder_format
+
     
     campaigns.campaign_name as activity_campaign_name 
 

--- a/models/intermediate/int_pardot__activities_join_enriched.sql
+++ b/models/intermediate/int_pardot__activities_join_enriched.sql
@@ -36,16 +36,6 @@ select
     list_email_natural_key,
 
 
-    /* An email specific URL builder was rolled out globally in late FY25, with full adoption across markets from FY26. See https://theirc.github.io/URLBuilder/#emailUrlGenPage . 
-    New attributes from the URL builder created on stg_pardot__list_email and passed through below */
-    email_url_builder_month_abbreviated,
-    email_url_builder_month_full_name,
-    email_url_builder_version_number,
-    email_url_builder_audience_segment_code,
-    email_url_builder_audience_segment_name,
-    email_url_builder_test_variant,
-    is_email_url_builder_format,
-
     
     campaigns.campaign_name as activity_campaign_name 
 

--- a/models/intermediate/int_pardot__activities_join_enriched.sql
+++ b/models/intermediate/int_pardot__activities_join_enriched.sql
@@ -33,6 +33,7 @@ select
     email_url_builder_month_full_name,
     email_url_builder_version_number,
     email_url_builder_audience_segment_code,
+    email_url_builder_audience_segment_name,
     email_url_builder_test_variant,
     is_email_url_builder_format,
 

--- a/models/intermediate/int_pardot__activities_join_enriched.sql
+++ b/models/intermediate/int_pardot__activities_join_enriched.sql
@@ -34,7 +34,7 @@ select
     email_url_builder_version_number,
     email_url_builder_audience_segment_code,
     email_url_builder_test_variant,
-    is_email_url_builder_format
+    is_email_url_builder_format,
 
     
     campaigns.campaign_name as activity_campaign_name 

--- a/models/intermediate/int_pardot__activities_join_enriched.sql
+++ b/models/intermediate/int_pardot__activities_join_enriched.sql
@@ -16,16 +16,25 @@ list_emails as (
 select 
     visitor_activity.*,
     
-    is_mmus_formated_list_email_name,
-    list_email_natural_key,
+    /*basics */
     list_email_sent_at,
-    list_email_keyword_segment,
-    list_email_keyword_status,
-    list_email_keyword_type,
-    list_email_name_parsed_topic,
-
     list_email_name,
     list_email_subject,
+    
+    /* parsed dimensions from list email name generated via the URL builder*/
+    list_email_fiscal_year,
+    list_email_month_abbreviated,
+    list_email_version_number,
+    list_email_audience_segment_code,
+    list_email_audience_segment_name,
+    list_email_test_variant,
+    list_email_type,
+
+    /* flags and keys */
+    is_list_email_url_builder_format,
+    list_email_name_internal_id,
+    list_email_natural_key,
+
 
     /* An email specific URL builder was rolled out globally in late FY25, with full adoption across markets from FY26. See https://theirc.github.io/URLBuilder/#emailUrlGenPage . 
     New attributes from the URL builder created on stg_pardot__list_email and passed through below */


### PR DESCRIPTION
As part of [issue number 1291 on the era-dbt repo](https://github.com/theirc/er-analytics-dbt/issues/1291), passes through [columns developed ](https://github.com/theirc/er-analytics-dbt_pardot_source/pull/9)on `pardot_source`, to ensure they are available for intermediate joining on pardot before being passed to er-analytics-dbt for further modelling with donations


 `list_email_month_abbreviated`
 `list_email_month_full_name`
`list_email_version_number`
 `list_email_audience_segment_code`
 `list_email_audience_segment_name`
 `list_email_test_variant`
`is_list_email_url_builder_format` 
`list_email_internal_name_id`
`list_email_natural_key`
Passing new email dimensions made on `pardot_source` to the `pardot` model `int_pardot__activities_join_enriched`, created at 

### Local run/logs
```
dbt run -s +email_activities
15:04:19  Done. PASS=67 WARN=0 ERROR=0 SKIP=0 TOTAL=67
```

