### PR TITLE
Creating `pardot__list_email_identifiers` model - star schema model design 

### DIFF
--- a/models/pardot.yml
+++ b/models/pardot.yml
@@ -64,7 +64,23 @@ models:
         description: Timestamp of most recent email activity of a list member
       - name: most_recent_visit_activity_timestamp
         description: Timestamp of most recent visit activity of a list member
-
+  - name: pardot__list_email_identifiers
+    description: Each record represents a unique list email in Pardot, identified by a natural key. This model aggregates relevant information for data quality and reporting purposes, and flags potential duplicates for further investigation.
+    columns:
+      - name: list_email_natural_key
+        description: A natural key that identifies unique list email entries in Pardot, which may be based on a combination of attributes such as list ID and email name.
+      - name: list_email_name
+        description: The name of the list email in Pardot. In cases where there are multiple entries with the same natural key, this field aggregates all distinct names for reporting purposes.
+      - name: list_email_subject
+        description: The subject of the list email in Pardot. In cases where there are multiple entries with the same natural key, this field aggregates all distinct subjects for reporting purposes.
+      - name: list_email_type
+        description: The type of the list email in Pardot. In cases where there are multiple entries with the same natural key, this field aggregates all distinct types for reporting purposes.
+      - name: first_list_email_sent_at
+        description: The timestamp of when the first email with this natural key was sent in Pardot.
+      - name: last_list_email_sent_at
+        description: The timestamp of when the most recent email with this natural key was sent in Pardot.
+      - name: has_duplicate_list_email_entries
+        description: A boolean flag indicating whether there are multiple entries in Pardot with the same natural key, which may suggest potential duplicates that require further investigation.
   - name: pardot__opportunities
     description: Each record represents an opportunity in Pardot.
     columns:

--- a/models/pardot__list_email_identifiers.sql
+++ b/models/pardot__list_email_identifiers.sql
@@ -1,0 +1,21 @@
+    -- This model identifies unique list email entries based on a natural key and aggregates relevant information for data quality and reporting purposes, within Power BI. It also flags potential duplicates for further investigation.
+    select
+        list_email_natural_key,
+
+        /* Catching potential cases where there are multiple emails with the same natural key, using listagg to show all values within Power BI reporting for data quality purposes */
+        listagg(distinct list_email_name, ', ') as list_email_name,
+        listagg(distinct list_email_subject, ', ') as list_email_subject,
+        listagg(distinct list_email_type, ', ') as list_email_type,
+
+        /*Catching potential cases where there are multiple emails with the same natural key that were sent at different times - for data quality / tracking purposes */
+        min(list_email_sent_at) as first_list_email_sent_at,
+        max(list_email_sent_at) as last_list_email_sent_at, 
+
+        /*counts */
+        count(*) as count_list_email_entries,
+        case when count_list_email_entries > 1 then true else false end as has_duplicate_list_email_entries
+        
+    from {{ ref('stg_pardot__list_email') }}
+    where list_email_natural_key is not null
+    group by
+        list_email_natural_key


### PR DESCRIPTION
### What this does and why

With star schema design in mind, this PR aims to make `list_email` aggregations, flags and enrichments available in a standalone intermediate model. This will replace our current set up where we are joining `list_email` dimensional attributes to donations within the `int_activity_definition__email_donations` model.

When we clean up/remove `list_email` code from the `int_activity_definition__email_donations model` , we will have more modularity with distinct outcomes in mind - at a high level: 

- email donations
- list email activities
- list emails 


These tables can then be joined in Power BI using `list_email_natural_key`, with a star schema design in mind

***Diagram below is from Claude - little rough round the edges***
<img width="876" height="706" alt="image" src="https://github.com/user-attachments/assets/d7b9ae4f-6ed1-4f8f-95d4-ed62cabd1052" />


### Run logs
(dbt-env-dbx) PS C:\Users\AndrewLo\Repos\er-analytics-dbt> dbt run -s pardot__list_email_identifiers
11:13:52  Done. PASS=6 WARN=0 ERROR=0 SKIP=0 TOTAL=6


### Testing

Nothing too intense since no new code is being introduced -  just checking that the model runs and identifies duplicates and that the listagg function is working correctly

<img width="1425" height="493" alt="image" src="https://github.com/user-attachments/assets/69ea8966-ed9b-48bc-99f9-d92934a33fbd" />


