### PR TITLE
 Merge `main-databricks` to `main` on pardot

### DIFF
--- a/models/intermediate/int_pardot__activities_join_enriched.sql
+++ b/models/intermediate/int_pardot__activities_join_enriched.sql
@@ -27,6 +27,15 @@ select
     list_email_name,
     list_email_subject,
 
+    /* An email specific URL builder was rolled out globally in late FY25, with full adoption across markets from FY26. See https://theirc.github.io/URLBuilder/#emailUrlGenPage . 
+    New attributes from the URL builder created on stg_pardot__list_email and passed through below */
+    email_url_builder_month_abbreviated,
+    email_url_builder_month_full_name,
+    email_url_builder_version_number,
+    email_url_builder_audience_segment_code,
+    email_url_builder_test_variant,
+    is_email_url_builder_format
+
     
     campaigns.campaign_name as activity_campaign_name 
 

--- a/models/intermediate/int_pardot__activities_join_enriched.sql
+++ b/models/intermediate/int_pardot__activities_join_enriched.sql
@@ -36,16 +36,6 @@ select
     list_email_natural_key,
 
 
-    /* An email specific URL builder was rolled out globally in late FY25, with full adoption across markets from FY26. See https://theirc.github.io/URLBuilder/#emailUrlGenPage . 
-    New attributes from the URL builder created on stg_pardot__list_email and passed through below */
-    email_url_builder_month_abbreviated,
-    email_url_builder_month_full_name,
-    email_url_builder_version_number,
-    email_url_builder_audience_segment_code,
-    email_url_builder_audience_segment_name,
-    email_url_builder_test_variant,
-    is_email_url_builder_format,
-
     
     campaigns.campaign_name as activity_campaign_name 
 

--- a/models/intermediate/int_pardot__activities_join_enriched.sql
+++ b/models/intermediate/int_pardot__activities_join_enriched.sql
@@ -33,6 +33,7 @@ select
     email_url_builder_month_full_name,
     email_url_builder_version_number,
     email_url_builder_audience_segment_code,
+    email_url_builder_audience_segment_name,
     email_url_builder_test_variant,
     is_email_url_builder_format,
 

--- a/models/intermediate/int_pardot__activities_join_enriched.sql
+++ b/models/intermediate/int_pardot__activities_join_enriched.sql
@@ -34,7 +34,7 @@ select
     email_url_builder_version_number,
     email_url_builder_audience_segment_code,
     email_url_builder_test_variant,
-    is_email_url_builder_format
+    is_email_url_builder_format,
 
     
     campaigns.campaign_name as activity_campaign_name 

--- a/models/intermediate/int_pardot__activities_join_enriched.sql
+++ b/models/intermediate/int_pardot__activities_join_enriched.sql
@@ -16,16 +16,25 @@ list_emails as (
 select 
     visitor_activity.*,
     
-    is_mmus_formated_list_email_name,
-    list_email_natural_key,
+    /*basics */
     list_email_sent_at,
-    list_email_keyword_segment,
-    list_email_keyword_status,
-    list_email_keyword_type,
-    list_email_name_parsed_topic,
-
     list_email_name,
     list_email_subject,
+    
+    /* parsed dimensions from list email name generated via the URL builder*/
+    list_email_fiscal_year,
+    list_email_month_abbreviated,
+    list_email_version_number,
+    list_email_audience_segment_code,
+    list_email_audience_segment_name,
+    list_email_test_variant,
+    list_email_type,
+
+    /* flags and keys */
+    is_list_email_url_builder_format,
+    list_email_name_internal_id,
+    list_email_natural_key,
+
 
     /* An email specific URL builder was rolled out globally in late FY25, with full adoption across markets from FY26. See https://theirc.github.io/URLBuilder/#emailUrlGenPage . 
     New attributes from the URL builder created on stg_pardot__list_email and passed through below */

--- a/models/pardot.yml
+++ b/models/pardot.yml
@@ -64,7 +64,23 @@ models:
         description: Timestamp of most recent email activity of a list member
       - name: most_recent_visit_activity_timestamp
         description: Timestamp of most recent visit activity of a list member
-
+  - name: pardot__list_email_identifiers
+    description: Each record represents a unique list email in Pardot, identified by a natural key. This model aggregates relevant information for data quality and reporting purposes, and flags potential duplicates for further investigation.
+    columns:
+      - name: list_email_natural_key
+        description: A natural key that identifies unique list email entries in Pardot, which may be based on a combination of attributes such as list ID and email name.
+      - name: list_email_name
+        description: The name of the list email in Pardot. In cases where there are multiple entries with the same natural key, this field aggregates all distinct names for reporting purposes.
+      - name: list_email_subject
+        description: The subject of the list email in Pardot. In cases where there are multiple entries with the same natural key, this field aggregates all distinct subjects for reporting purposes.
+      - name: list_email_type
+        description: The type of the list email in Pardot. In cases where there are multiple entries with the same natural key, this field aggregates all distinct types for reporting purposes.
+      - name: first_list_email_sent_at
+        description: The timestamp of when the first email with this natural key was sent in Pardot.
+      - name: last_list_email_sent_at
+        description: The timestamp of when the most recent email with this natural key was sent in Pardot.
+      - name: has_duplicate_list_email_entries
+        description: A boolean flag indicating whether there are multiple entries in Pardot with the same natural key, which may suggest potential duplicates that require further investigation.
   - name: pardot__opportunities
     description: Each record represents an opportunity in Pardot.
     columns:

--- a/models/pardot__list_email_identifiers.sql
+++ b/models/pardot__list_email_identifiers.sql
@@ -1,0 +1,21 @@
+    -- This model identifies unique list email entries based on a natural key and aggregates relevant information for data quality and reporting purposes, within Power BI. It also flags potential duplicates for further investigation.
+    select
+        list_email_natural_key,
+
+        /* Catching potential cases where there are multiple emails with the same natural key, using listagg to show all values within Power BI reporting for data quality purposes */
+        listagg(distinct list_email_name, ', ') as list_email_name,
+        listagg(distinct list_email_subject, ', ') as list_email_subject,
+        listagg(distinct list_email_type, ', ') as list_email_type,
+
+        /*Catching potential cases where there are multiple emails with the same natural key that were sent at different times - for data quality / tracking purposes */
+        min(list_email_sent_at) as first_list_email_sent_at,
+        max(list_email_sent_at) as last_list_email_sent_at, 
+
+        /*counts */
+        count(*) as count_list_email_entries,
+        case when count_list_email_entries > 1 then true else false end as has_duplicate_list_email_entries
+        
+    from {{ ref('stg_pardot__list_email') }}
+    where list_email_natural_key is not null
+    group by
+        list_email_natural_key

--- a/models/pardot__prospects.sql
+++ b/models/pardot__prospects.sql
@@ -12,7 +12,7 @@ with prospects as (
 
     select 
         prospect_id,
-        account_id,
+        account_id
     from {{ ref('int_pardot__prospects_join_enriched') }}
 
 ), joined as (

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - git: "https://github.com/theirc/er-analytics-dbt_pardot_source"
-    revision: main
+    revision: main-databricks

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - git: "https://github.com/theirc/er-analytics-dbt_pardot_source"
-    revision: main-databricks
+    revision: "main-databricks"


### PR DESCRIPTION
Ensure latest code in this repo is routed from main-databricks to main, following migration from snowflake > databricks


- [x] Merge main-databricks to main on er-analytics-dbt_pardot
- [x] Update packages.yml on er-analytics-dbt_pardot to point pardot_source at main (note: this will be done via a merge conflict on github because packages.yml was listed as 'main' on the main branch vs 'main-databricks' on the 'main-databricks' branch